### PR TITLE
Controlling the TS solver tolerances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ examples/heat_exchanger/2D_mesh.geo
 .eggs/
 
 *.txt
+
+**/.coverage


### PR DESCRIPTION
It might happen that the user's tolerances for the TS solver are too high. The TS solver will try to take many small steps without much success. We automatically restart the optimization iteration with lower solver tolerances. We relax them again if the TS solver successfully finishes on time.